### PR TITLE
Un-hardcode selenium server version, bumped to 2.45.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ WORKDIR /workdir
 RUN cd /workdir
 RUN git clone https://github.com/yveshwang/selenium-2step.git selenium-2step/
 RUN cp /workdir/selenium-2step/Xvfb /etc/init.d/.
+RUN source /workdir/selenium-2step/config.env
 RUN update-rc.d Xvfb defaults
 RUN service Xvfb start
-RUN wget http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.1.jar
+RUN wget -O $SELENIUM_JAR $SELENIUM_DOWNLOAD_URL
 RUN wget http://chromedriver.storage.googleapis.com/2.10/chromedriver_linux64.zip
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN mv *.zip /usr/local/selenium/.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,9 @@ cp /vagrant/Xvfb /etc/init.d/.
 update-rc.d Xvfb defaults
 service Xvfb start
 echo ==== Setting up selenium ====
-wget http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.1.jar
+cp /vagrant/config.env /usr/local/selenium
+source /usr/local/selenium/config.env
+wget -O $SELENIUM_JAR $SELENIUM_DOWNLOAD_URL
 mv *.jar /usr/local/selenium/.
 cp /vagrant/selenium-grid /etc/init.d/.
 update-rc.d selenium-grid defaults

--- a/config.env
+++ b/config.env
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+SELENIUM_DOWNLOAD_URL=http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar
+SELENIUM_JAR=selenium-server-standalone.jar
+

--- a/selenium-grid
+++ b/selenium-grid
@@ -17,13 +17,17 @@
 SELENIUM_COMPONENT="Selenium Grid"
 INTERNAL_NAME=selenium-server
 SELENIUM_HOME=/usr/local/selenium
+
+# Load the config
+source $SELENIUM_HOME/config.env
+
 LOG_DIR=$SELENIUM_HOME
 ERROR_LOG=$LOG_DIR/${INTERNAL_NAME}_error.log
 STD_LOG=$LOG_DIR/${INTERNAL_NAME}_std.log
 TMP_DIR=$SELENIUM_HOME
 PID_FILE=$TMP_DIR/${INTERNAL_NAME}.pid
 JAVA=/usr/bin/java
-SELENIUM_APP="$SELENIUM_HOME/selenium-server-standalone-2.42.1.jar"
+SELENIUM_APP="$SELENIUM_HOME/$SELENIUM_JAR"
 USER=selenium
 XDISPLAY="export DISPLAY=:99"
 

--- a/selenium-node
+++ b/selenium-node
@@ -17,13 +17,17 @@
 SELENIUM_COMPONENT="Selenium node"
 INTERNAL_NAME=selenium-node
 SELENIUM_HOME=/usr/local/selenium
+
+# Load the config
+source $SELENIUM_HOME/config.env
+
 LOG_DIR=$SELENIUM_HOME
 ERROR_LOG=$LOG_DIR/${INTERNAL_NAME}_error.log
 STD_LOG=$LOG_DIR/${INTERNAL_NAME}_std.log
 TMP_DIR=$SELENIUM_HOME
 PID_FILE=$TMP_DIR/${INTERNAL_NAME}.pid
 JAVA=/usr/bin/java
-SELENIUM_APP="$SELENIUM_HOME/selenium-server-standalone-2.42.1.jar"
+SELENIUM_APP="$SELENIUM_HOME/$SELENIUM_JAR"
 USER=selenium
 XDISPLAY="export DISPLAY=:99"
 CHROMEDRIVER_PATH=/usr/local/selenium/chromedriver


### PR DESCRIPTION
Selenium version 2.42.1 was hardcoded in several places. I replaced all references to the jar with a non-versioned file called `selenium-server-standalone.jar`. I also put the download url in a config.env file, so you can easily update the version by changing the download url. 
